### PR TITLE
Setup.py does not try to load requests anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import sys
 from setuptools import setup, find_packages
 
-version = __import__('pysendy').__version__
+version = '0.0.4.dev0'
 
 setup(
     name='pysendy',


### PR DESCRIPTION
When pysendy was in a requirements.txt (pip) it crashed because requests was not installed yet.
